### PR TITLE
Remove illegal chars from generated domain words

### DIFF
--- a/lib/src/internet.dart
+++ b/lib/src/internet.dart
@@ -84,7 +84,10 @@ class Internet {
   /// ```dart
   ///   faker.internet.domainWord();
   /// ```
-  String domainWord() => random.element(lastnames).toLowerCase();
+  String domainWord() => random
+    .element(lastnames)
+    .toLowerCase()
+    .replaceAll(new RegExp(r'[^a-z0-9\-]'), ''); // -- remove illegal domain characters
 
   /// Generates a URI with the given [protocol].
   ///


### PR DESCRIPTION
This fixes Issue #2 

More info here: https://en.wikipedia.org/wiki/Domain_name#Technical_requirements_and_process