### PR TITLE
Add generics to `randomGenerator.element()`

### DIFF
--- a/lib/src/random_generator.dart
+++ b/lib/src/random_generator.dart
@@ -8,7 +8,7 @@ class RandomGenerator {
   const RandomGenerator();
 
   /// Plucks a random element from the given [list].
-  element(List list) {
+  T element<T>(List<T> list) {
     return list[_rng.nextInt(list.length)];
   }
 


### PR DESCRIPTION
This change allows code like this, that would normally cause either `cannot find declaration to go to` or ```getter `values` isn't defined for the class Object```, to resolve properly:

```dart
var items = [
  {'a': 'foo', 'b': 'bar'},
  {'a': 'zip', 'b': 'zap'}
]
var chosenItem = faker.randomGenerator.element(items).values;
```