### PR TITLE
Fix typo in lorem.sentences

### DIFF
--- a/lib/src/lorem.dart
+++ b/lib/src/lorem.dart
@@ -40,6 +40,6 @@ class Lorem {
   ///   faker.lorem.sentences(5);
   /// ```
   List<String> sentences(numberOfSentences) {
-    return Iterable<int>.generate(numberOfSentences).map((_) => word()).toList();
+    return Iterable<int>.generate(numberOfSentences).map((_) => sentence()).toList();
   }
 }


### PR DESCRIPTION
Currently `lorem.sentences(n)` returns `n` words instead of sentences.
Fix typo word -> sentence