### PR TITLE
Adds Image faker

### DIFF
--- a/lib/src/faker.dart
+++ b/lib/src/faker.dart
@@ -7,6 +7,7 @@ import 'conference.dart';
 import 'currency.dart';
 import 'food.dart';
 import 'guid.dart';
+import 'image.dart';
 import 'internet.dart';
 import 'job.dart';
 import 'person.dart';
@@ -22,6 +23,7 @@ class Faker {
   final Currency currency;
   final Food food;
   final Guid guid;
+  final Image image;
   final Internet internet;
   final Job job;
   final Lorem lorem;
@@ -37,6 +39,7 @@ class Faker {
         currency = const Currency(),
         food = const Food(),
         guid = const Guid(),
+        image = const Image(),
         internet = const Internet(),
         job = const Job(),
         lorem = const Lorem(),

--- a/lib/src/image.dart
+++ b/lib/src/image.dart
@@ -2,7 +2,7 @@ class Image {
   const Image();
 
   /// Generates a url to a image random image. The size of image is determined
-  /// by `width` and `height` paramters. You can choose the image categories related
+  /// by `width` and `height` parameters. You can choose the image categories related
   /// by the `keywords` parameter separeted by comma .
   /// 
   /// Example:

--- a/lib/src/image.dart
+++ b/lib/src/image.dart
@@ -1,0 +1,37 @@
+class Image {
+  const Image();
+
+  /// Generates a url to a image random image. The size of image is determined
+  /// by `width` and `height` paramters. You can choose the image categories related
+  /// by the `keywords` parameter separeted by comma .
+  /// 
+  /// Example:
+  /// ```dart
+  ///   faker.image.image(1600, 1200, 'nature, people');
+  /// ```
+  String image({int width = 640, int height = 480, String keywords = ''}) {
+    return _imageUrl(width, height, keywords);
+  }
+
+  /// Build a url to a image random image from unsplash
+  ///
+  /// Example:
+  /// ```dart
+  ///   this._imageUrl(1600, 1200, 'nature');
+  /// ```
+  String _imageUrl(int width, int height, String keywords) {    
+    var url = 'https://source.unsplash.com';
+    
+    url += '/${width}x${height}';
+
+    if (keywords.isNotEmpty) {
+      var keywordFormat =
+          new RegExp(r'^([A-Za-z0-9].+,[A-Za-z0-9]+)$|^([A-Za-z0-9]+)$');
+      if (keywordFormat.hasMatch(keywords)) {
+        url += '?' + keywords;
+      }
+    }
+
+    return url;
+  }
+}

--- a/lib/src/image.dart
+++ b/lib/src/image.dart
@@ -7,9 +7,9 @@ class Image {
   /// 
   /// Example:
   /// ```dart
-  ///   faker.image.image(1600, 1200, 'nature, people');
+  ///   faker.image.image(width: 1200, height: 900, keywords: ['people', 'nature']);
   /// ```
-  String image({int width = 640, int height = 480, String keywords = ''}) {
+  String image({int width = 640, int height = 480, List<String> keywords = const []}) {
     return _imageUrl(width, height, keywords);
   }
 
@@ -19,16 +19,16 @@ class Image {
   /// ```dart
   ///   this._imageUrl(1600, 1200, 'nature');
   /// ```
-  String _imageUrl(int width, int height, String keywords) {    
+  String _imageUrl(int width, int height, List<String> keywords) {
     var url = 'https://source.unsplash.com';
     
     url += '/${width}x${height}';
 
     if (keywords.isNotEmpty) {
       var keywordFormat =
-          new RegExp(r'^([A-Za-z0-9].+,[A-Za-z0-9]+)$|^([A-Za-z0-9]+)$');
-      if (keywordFormat.hasMatch(keywords)) {
-        url += '?' + keywords;
+          new RegExp(r'^([A-Za-z0-9].+,[A-Za-z0-9]+)$|^([A-Za-z0-9]+)$');          
+      if (keywords.any(keywordFormat.hasMatch)) {
+        url += '?' + keywords.join(',');
       }
     }
 

--- a/lib/src/image.dart
+++ b/lib/src/image.dart
@@ -17,7 +17,7 @@ class Image {
   ///
   /// Example:
   /// ```dart
-  ///   this._imageUrl(1600, 1200, 'nature');
+  ///   this._imageUrl(1600, 1200,  ['people']);
   /// ```
   String _imageUrl(int width, int height, List<String> keywords) {
     var url = 'https://source.unsplash.com';

--- a/test/runner.dart
+++ b/test/runner.dart
@@ -4,6 +4,7 @@ import 'specs/company.dart' as company;
 import 'specs/currency.dart' as currency;
 import 'specs/food.dart' as food;
 import 'specs/guid.dart' as guid;
+import 'specs/image.dart' as image;
 import 'specs/internet.dart' as internet;
 import 'specs/job.dart' as job;
 import 'specs/lorem.dart' as lorem;
@@ -19,6 +20,7 @@ void main() {
   currency.main();
   food.main();
   guid.main();
+  image.main();
   internet.main();
   job.main();
   lorem.main();

--- a/test/specs/image.dart
+++ b/test/specs/image.dart
@@ -1,0 +1,33 @@
+import 'package:faker/faker.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Image', () {
+    group('Custom image', () {
+      test('should be able to generate a url image with default params', () {
+        expect(faker.image.image(), 'https://source.unsplash.com/640x480');
+      });
+
+      test('should be able to generate a url image with custom size', () {
+        expect(faker.image.image(width: 1600, height: 900),
+            'https://source.unsplash.com/1600x900');
+      });
+
+      test('should be able to generate a url image with nature keyword', () {
+        expect(faker.image.image(keywords: "nature"),
+            'https://source.unsplash.com/640x480?nature');
+      });
+
+      test('should be able to generate a url for image with custom size and technology keyword', () {
+        expect(
+            faker.image.image(width: 1200, height: 900, keywords: "technology"),
+            'https://source.unsplash.com/1200x900?technology');
+      });
+
+      test('should be able to generate a url image with nature and people keywords', () {
+        expect(faker.image.image(keywords: "nature,people"),
+            'https://source.unsplash.com/640x480?nature,people');
+      });
+    });
+  });
+}

--- a/test/specs/image.dart
+++ b/test/specs/image.dart
@@ -14,18 +14,23 @@ void main() {
       });
 
       test('should be able to generate a url image with nature keyword', () {
-        expect(faker.image.image(keywords: "nature"),
+        expect(faker.image.image(keywords: ["nature"]),
             'https://source.unsplash.com/640x480?nature');
       });
 
-      test('should be able to generate a url for image with custom size and technology keyword', () {
+      test(
+          'should be able to generate a url for image with custom size and technology keyword',
+          () {
         expect(
-            faker.image.image(width: 1200, height: 900, keywords: "technology"),
+            faker.image
+                .image(width: 1200, height: 900, keywords: ["technology"]),
             'https://source.unsplash.com/1200x900?technology');
       });
 
-      test('should be able to generate a url image with nature and people keywords', () {
-        expect(faker.image.image(keywords: "nature,people"),
+      test(
+          'should be able to generate a url image with nature and people keywords',
+          () {
+        expect(faker.image.image(keywords: ["nature", "people"]),
             'https://source.unsplash.com/640x480?nature,people');
       });
     });


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #19

## Testing and Review Notes
 Generates a url to a image random image. The size of image is determined  by `width` and `height` paramters. You can choose the image categories related  by the `keywords` parameter separeted by comma .
 
Example:
 ```dart
    faker.image.image(width: 1200, height: 900, keywords: 'nature,people');
 ```
Result: https://source.unsplash.com/1200x900?nature,people


## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [X] double check the original issue to confirm it is fully satisfied
- [X] add testing notes and screenshots in PR description to help guide reviewers
