### PR TITLE
Chaged the regex for restaurant name

### DIFF
--- a/test/specs/food.dart
+++ b/test/specs/food.dart
@@ -1,12 +1,14 @@
 import 'package:test/test.dart';
 import 'package:faker/faker.dart';
 
+import 'package:faker/src/data/food/restaurants.dart';
+
 void main() {
   var faker = Faker();
 
-  group('food', () {
+  group('food', () {    
     test('should be able to generate restaurant', () {
-      expect(faker.food.restaurant(), matches(RegExp(r"^([\w\s\'-])+$")));
+      expect(faker.food.restaurant(), matches(RegExp(r"^([\w\s\&\/\,\.\ö\’\'-])+$")));
     });
 
     test('should be able to generate dish', () {


### PR DESCRIPTION
Before: r"^([\w\s\'-])+$"
After:  r"^([\w\s\&\/\,\.\ö\’\'-])+$

## Connection with issue(s)

Resolve issue #22 

Connected to #21 


## Testing and Review Notes

Use a restaurant name with special characters like  & / , . ö ’

## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [X] double check the original issue to confirm it is fully satisfied
- [X] add testing notes and screenshots in PR description to help guide reviewers
