### PR TITLE
Fix safe email method by removing apostrophe

### DIFF
--- a/lib/src/internet.dart
+++ b/lib/src/internet.dart
@@ -60,7 +60,7 @@ class Internet {
   ///   faker.internet.safeEmail();
   /// ```
   String safeEmail() =>
-      [userName(), 'example.${random.element(_domainSuffixes)}'].join('@');
+      [userName().replaceAll('\'', '-'), domainName()].join('@');
 
   /// Generates a user name.
   ///


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue: safeEmail() sometimes returns an invalid email because some last names have apostrophes (O'Connell, O'Hara...)

## Testing and Review Notes


## To Do

- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
