### PR TITLE
feat: Extended color faker with rgb method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 2.2.0
+
+### Features
+
+- Add `rgbColor` method to colors faker.
+```dart
+faker.colors.rgbColor();
+faker.colors.rgbColor(prefix: '0x');
+faker.colors.rgbColor(casing: Casing.upper);
+faker.colors.rgbColor(format: Format.css);
+faker.colors.rgbColor(includeAlpha: true);
+```
+
+### Fixes
+- Fix safe email method by removing apostrophe. [PR #70](https://github.com/drager/faker/pull/70)
+
+### Maintenance
+- Update lints package. [PR #71](https://github.com/drager/faker/pull/71)
+
 ## 2.1.0
 
 ### Features

--- a/lib/faker.dart
+++ b/lib/faker.dart
@@ -6,6 +6,7 @@ export 'src/faker.dart';
 export 'src/random_generator.dart';
 
 export 'src/address.dart';
+export 'src/colors.dart';
 export 'src/conference.dart';
 export 'src/company.dart';
 export 'src/currency.dart';

--- a/lib/src/colors.dart
+++ b/lib/src/colors.dart
@@ -1,7 +1,19 @@
 import 'data/colors/colors.dart';
 import 'random_generator.dart';
 
+enum Casing {
+  lower,
+  upper,
+}
+
+enum Format {
+  hex,
+  css,
+}
+
 class Color {
+  static const _hexChars = '0123456789abcdef';
+
   const Color(this.random);
 
   final RandomGenerator random;
@@ -21,4 +33,69 @@ class Color {
   ///   faker.colors.commonColor();
   /// ```
   String commonColor() => random.element(commonColors);
+
+  /// Generates a [String] rgb color.
+  ///
+  /// Example
+  /// ```dart
+  /// faker.colors.rgbColor();
+  /// faker.colors.rgbColor(prefix: '0x');
+  /// faker.colors.rgbColor(casing: Casing.upper);
+  /// faker.colors.rgbColor(casing: Casing.lower);
+  /// faker.colors.rgbColor(prefix: '#', casing: Casing.lower);
+  /// faker.colors.rgbColor(format: Format.hex, casing: Casing.lower');
+  /// faker.colors.rgbColor(format: Format.css);
+  /// faker.colors.rgbColor(includeAlpha: true);
+  /// faker.colors.rgbColor(format: Format.css, includeAlpha: true);
+  /// ```
+  String rgbColor({
+    final String prefix = '#',
+    final Casing casing = Casing.lower,
+    final Format format = Format.hex,
+    final bool includeAlpha = false,
+  }) {
+    if (format == Format.hex) {
+      var length = includeAlpha ? 8 : 6;
+      String color = '';
+      while (length-- > 0) {
+        color += _hexChars[(random.integer(16)) | 0];
+      }
+
+      return _formatHexColor(color, prefix: prefix, casing: casing);
+    }
+
+    var color = List.generate(3, (_) => random.integer(255));
+    if (includeAlpha) {
+      return 'rgba(${color[0]}, ${color[1]}, ${color[2]}, ${random.decimal()})';
+    }
+
+    return 'rgb(${color[0]}, ${color[1]}, ${color[2]})';
+  }
+
+  String _formatHexColor(
+    String hexColor, {
+    required Casing casing,
+    String? prefix,
+  }) {
+    switch (casing) {
+      case Casing.upper:
+        {
+          hexColor = hexColor.toUpperCase();
+          break;
+        }
+      case Casing.lower:
+        {
+          hexColor = hexColor.toLowerCase();
+          break;
+        }
+      default:
+        break;
+    }
+
+    if (prefix != null) {
+      hexColor = prefix + hexColor;
+    }
+
+    return hexColor;
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: faker
-version: 2.1.1
+version: 2.2.0
 description: A library for generating fake data. faker is heavily inspired by the Python package faker and, the Ruby package ffaker.
 homepage: https://github.com/drager/faker
 environment:

--- a/test/specs/colors.dart
+++ b/test/specs/colors.dart
@@ -1,3 +1,4 @@
+import 'package:faker/src/colors.dart';
 import 'package:test/test.dart';
 import 'package:faker/faker.dart';
 
@@ -20,5 +21,49 @@ void main() {
                 matches(r"^[\w,' ]+[\w ]$")));
       }
     });
+
+    test('should be able to generate a rgb color', () {
+      final color = faker.color.rgbColor();
+      expect(color, matches(r'^(#[a-f0-9]{6})$'));
+    });
+
+    test('should be able to generate a rgb color with 0x prefix', () {
+      final color = faker.color.rgbColor(prefix: '0x');
+      expect(color, matches(r'^(0x[a-f0-9]{6})$'));
+    });
+
+    test('should be able to generate a rgb color with 0x prefix lowercase', () {
+      final color = faker.color.rgbColor(prefix: '0x', casing: Casing.lower);
+      expect(color, matches(r'^(0x[a-f0-9]{6})$'));
+    });
+
+    test('should be able to generate a rgb color with 0x prefix uppercase', () {
+      final color = faker.color.rgbColor(prefix: '0x', casing: Casing.upper);
+      expect(color, matches(r'^(0x[A-F0-9]{6})$'));
+    });
+
+    test('should be able to generate a rgb color using css format', () {
+      final color = faker.color.rgbColor(format: Format.css);
+      expect(color, matches(r'^(rgb\([0-9]{1,3}, [0-9]{1,3}, [0-9]{1,3}\))$'));
+    });
+
+    test('should be able to generate a rgb color using alpha', () {
+      final color = faker.color.rgbColor(includeAlpha: true);
+      expect(color, matches(r'^(#[a-fA-F0-9]{8})$'));
+    });
+
+    test(
+      'should be able to generate a rgb color using css format and alpha',
+      () {
+        final color = faker.color.rgbColor(
+          format: Format.css,
+          includeAlpha: true,
+        );
+        expect(
+          color,
+          matches(r'^(rgba\([0-9]{1,3}, [0-9]{1,3}, [0-9]{1,3}, \d*\.?\d*\))$'),
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
Implemented new RGB method for colors faker.
**The method was rewritten from Typescript from the faker.js repository: https://github.com/faker-js/faker/blob/next/src/modules/color/index.ts.**

Usage:
```dart
faker.colors.rgbColor();
faker.colors.rgbColor(prefix: '0x');
faker.colors.rgbColor(casing: Casing.upper);
faker.colors.rgbColor(format: Format.css);
faker.colors.rgbColor(includeAlpha: true);
```