### PR TITLE
feat: move Image to Lorem Picsum

### DIFF
--- a/lib/faker.dart
+++ b/lib/faker.dart
@@ -12,6 +12,7 @@ export 'src/company.dart';
 export 'src/currency.dart';
 export 'src/food.dart';
 export 'src/guid.dart';
+export 'src/image.dart';
 export 'src/internet.dart';
 export 'src/job.dart';
 export 'src/jwt.dart';

--- a/lib/src/image.dart
+++ b/lib/src/image.dart
@@ -1,9 +1,11 @@
 import 'dart:math';
 
+enum ImageFormat { jpg, webp }
+
 class Image {
   const Image();
 
-  /// Generates a url to a image random image. The size of image is determined
+  /// Generates a url to a random image. The size of image is determined
   /// by `width` and `height` parameters. You can choose the image categories related
   /// by the `keywords` parameter separeted by comma . By supplying the `random` parameter
   /// you can ensure a different image is returned with the same parameters.
@@ -12,40 +14,66 @@ class Image {
   /// ```dart
   ///   faker.image.image(width: 1200, height: 900, keywords: ['people', 'nature'], random: true);
   /// ```
-  String image(
-      {int width = 640,
-      int height = 480,
-      List<String> keywords = const [],
-      bool random = false}) {
-    return _imageUrl(width, height, keywords, random);
+  @Deprecated('Use loremPicsum instead for more control')
+  String image({
+    int width = 640,
+    int height = 480,
+    List<String> keywords = const [],
+    bool random = false,
+  }) {
+    return _imageUrl(
+      width,
+      height,
+      random: random ? Random().nextInt(100) : null,
+    ).toString();
   }
 
-  /// Build a url to a image random image from unsplash
+  /// Generates a url to a random image from Lorem Picsum. The size of image is determined
+  /// by `width` and `height` parameters. By supplying the `random` parameter
+  /// you can ensure a different image is returned with the same parameters.
+  /// You can also supply a `seed` parameter to get the same image every time.
+  /// You can also specify the image format by supplying the `imageFormat` parameter.
+  ///
+  /// See https://picsum.photos for more details.
+  String loremPicsum({
+    int width = 640,
+    int height = 480,
+    int? random,
+    String? seed,
+    ImageFormat? imageFormat,
+  }) {
+    return _imageUrl(
+      width,
+      height,
+      random: random,
+      seed: seed,
+      imageFormat: imageFormat,
+    ).toString();
+  }
+
+  /// Build a url to a image random image from Lorem Picsum.
   ///
   /// Example:
   /// ```dart
-  ///   this._imageUrl(1600, 1200,  ['people']);
+  ///   this._imageUrl(1600, 1200);
   /// ```
-  String _imageUrl(int width, int height, List<String> keywords,
-      [bool random = false]) {
-    var url = 'https://source.unsplash.com';
-
-    url += '/${width}x$height';
-
-    if (keywords.isNotEmpty) {
-      var keywordFormat =
-          RegExp(r'^([A-Za-z0-9].+,[A-Za-z0-9]+)$|^([A-Za-z0-9]+)$');
-      if (keywords.any(keywordFormat.hasMatch)) {
-        url += '?${keywords.join(',')}';
-        if (random) {
-          url = url += '&random=${Random().nextInt(100) + 1}';
-        }
-      }
-    } else {
-      if (random) {
-        url = url += '?random=${Random().nextInt(100) + 1}';
-      }
-    }
-    return url;
+  Uri _imageUrl(
+    int width,
+    int height, {
+    int? random,
+    String? seed,
+    ImageFormat? imageFormat,
+  }) {
+    final formatExt = imageFormat != null ? '.${imageFormat.name}' : '';
+    return Uri(
+      scheme: 'https',
+      host: 'picsum.photos',
+      pathSegments: [
+        if (seed != null) ...['seed', seed],
+        '$width',
+        '$height$formatExt',
+      ],
+      queryParameters: random != null ? {'random': '$random'} : null,
+    );
   }
 }

--- a/test/specs/image.dart
+++ b/test/specs/image.dart
@@ -5,33 +5,45 @@ void main() {
   group('Image', () {
     group('Custom image', () {
       test('should be able to generate a url image with default params', () {
-        expect(faker.image.image(), 'https://source.unsplash.com/640x480');
+        expect(
+          faker.image.image(),
+          'https://picsum.photos/640/480',
+        );
       });
 
       test('should be able to generate a url image with custom size', () {
-        expect(faker.image.image(width: 1600, height: 900),
-            'https://source.unsplash.com/1600x900');
-      });
-
-      test('should be able to generate a url image with nature keyword', () {
-        expect(faker.image.image(keywords: ["nature"]),
-            'https://source.unsplash.com/640x480?nature');
-      });
-
-      test(
-          'should be able to generate a url for image with custom size and technology keyword',
-          () {
         expect(
-            faker.image
-                .image(width: 1200, height: 900, keywords: ["technology"]),
-            'https://source.unsplash.com/1200x900?technology');
+          faker.image.image(width: 1600, height: 900),
+          'https://picsum.photos/1600/900',
+        );
       });
 
-      test(
-          'should be able to generate a url image with nature and people keywords',
-          () {
-        expect(faker.image.image(keywords: ["nature", "people"]),
-            'https://source.unsplash.com/640x480?nature,people');
+      test('keywords are deprecated and not added to the url', () {
+        expect(
+          faker.image.image(keywords: ["nature"]),
+          faker.image.image(keywords: ["technology"]),
+        );
+      });
+
+      test('random should add a generated param to avoid caching', () {
+        expect(
+          faker.image.image(random: true),
+          matches(RegExp('^https://picsum.photos/640/480\\?random=\\d+\$')),
+        );
+      });
+
+      test('seed should add a seed param to get the same image every time', () {
+        expect(
+          faker.image.loremPicsum(seed: 'test', width: 1600, height: 900),
+          'https://picsum.photos/seed/test/1600/900',
+        );
+      });
+
+      test('imageFormat should add an extension to the URL', () {
+        expect(
+          faker.image.loremPicsum(imageFormat: ImageFormat.webp),
+          'https://picsum.photos/640/480.webp',
+        );
       });
     });
   });


### PR DESCRIPTION
## Connection with issue(s)

It seems Unsplash no longer provides the API used by `Image`: apparently it was deprecated a while ago,[^1] and it just returns 404 now https://source.unsplash.com/640x480


## Testing and Review Notes

I reimplemented it for Lorem Picsum[^2] instead. I figure one could do a provider interface instead to support others, but maybe it's overkill...

The only drawback I see, is that this provider does not support keywords, so I kept the current signature for compatibility, but marked it as deprecated to let users know about it. Then, I created a new `loremPicsum` function, that exposes all of the API parameters for maximum flexibility.

Happy to change this API though, it was just the first idea I had!

## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers

[^1]: https://www.reddit.com/r/unsplash/comments/s13x4h/what_happened_to_sourceunsplashcom/
[^2]: https://picsum.photos